### PR TITLE
Fix rbenv-capistrano compatibility

### DIFF
--- a/lib/capistrano/delayed_job/helpers.rb
+++ b/lib/capistrano/delayed_job/helpers.rb
@@ -7,7 +7,7 @@ module Capistrano
       def bundle_delayed_job(*args)
         bin_dir = %w{bin script}.find{|dir_name| Dir.exists?(dir_name)}
         raise "No bin or script dir found in project" if bin_dir.nil?
-        SSHKit::Command.new(:nice, '-n 15', :bundle, :exec, "#{bin_dir}/delayed_job", args).to_command
+        SSHKit::Command.new("HOME=/home/$AS_USER", "RAILS_ENV=#{fetch(:rails_env)}", :nice, '-n 15', :bundle, :exec, "#{bin_dir}/delayed_job", args).to_command
       end
 
       def dj_template(template_name)

--- a/lib/capistrano/delayed_job/helpers.rb
+++ b/lib/capistrano/delayed_job/helpers.rb
@@ -7,7 +7,7 @@ module Capistrano
       def bundle_delayed_job(*args)
         bin_dir = %w{bin script}.find{|dir_name| Dir.exists?(dir_name)}
         raise "No bin or script dir found in project" if bin_dir.nil?
-        SSHKit::Command.new(:bundle, :exec, "#{bin_dir}/delayed_job", args).to_command
+        SSHKit::Command.new(:nice, '-n 15', :bundle, :exec, "#{bin_dir}/delayed_job", args).to_command
       end
 
       def dj_template(template_name)

--- a/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
+++ b/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
@@ -22,7 +22,7 @@ set -e
 interact() {
     op="$1"
     echo "Invoking DelayedJob with command '$op'"
-    CMD="cd $APP_ROOT && HOME=/home/$AS_USER RAILS_ENV=<%= fetch(:rails_env) %> <%= bundle_delayed_job("$op -n", fetch(:delayed_job_workers))%>"
+    CMD="cd $APP_ROOT && <%= bundle_delayed_job("$op -n", fetch(:delayed_job_workers))%>"
 
     if [ "$(id -un)" = "$AS_USER" ]; then
         eval $CMD

--- a/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
+++ b/lib/generators/capistrano/delayed_job/templates/delayed_job_init.erb
@@ -22,7 +22,7 @@ set -e
 interact() {
     op="$1"
     echo "Invoking DelayedJob with command '$op'"
-    CMD="cd $APP_ROOT && HOME=/home/$AS_USER RAILS_ENV=<%= fetch(:rails_env) %> nice -n 15 <%= bundle_delayed_job("$op -n", fetch(:delayed_job_workers))%>"
+    CMD="cd $APP_ROOT && HOME=/home/$AS_USER RAILS_ENV=<%= fetch(:rails_env) %> <%= bundle_delayed_job("$op -n", fetch(:delayed_job_workers))%>"
 
     if [ "$(id -un)" = "$AS_USER" ]; then
         eval $CMD


### PR DESCRIPTION
When using capistrano-rbenv, the unicorn_init file is generated incorrectly. This is caused by the way capistrano-rbenv prefixes `SSHKit::Command` with environmental variables. This results in the call to `SSHKit::Command.new(:bundle, :exec …` to generate `RBENV_ROOT=/opt/rbenv RBENV_VERSION=2.2.0 /opt/rbenv/bin/rbenv exec bundle exec`. 

This is caused by the following code in capistrano-rbenv:

    SSHKit.config.default_env.merge!({ rbenv_root: fetch(:rbenv_path), rbenv_version: fetch(:rbenv_ruby) })

The `bundle_delayed_job` helper currently uses the SSHKit::Command to access delayed_job:

    SSHKit::Command.new(:bundle, :exec, "#{bin_dir}/delayed_job", args).to_command

This generates the following when capistrano-rbenv is present: 

    RBENV_ROOT=/opt/rbenv RBENV_VERSION=2.2.0 /opt/rbenv/bin/rbenv exec bundle exec bin/delayed_job $op -n 1

SSHKit tries to encapsulate the the entire command so it adds parenthesis. The problem is that the environmental variables and the nice command are added to the command string outside of the `SSHKit::Command`.  You end up with the following: 

    cd $APP_ROOT && HOME=/home/$AS_USER RAILS_ENV=staging nice -n 15 ( RBENV_ROOT=/opt/rbenv RBENV_VERSION=2.2.0 /opt/rbenv/bin/rbenv exec bundle exec bin/delayed_job $op -n 1 )

This will not work for a couple of reasons. The parenthesis are added because environmental variables are being added by SSHKit. Removing the parenthesis does not work either, because then you are passing an environmental variable to the nice command, which is expecting an executable.

By moving nice and the environmental variables into the `SSHKit::Command `, the command is correctly generated:

    CMD="cd $APP_ROOT && ( RBENV_ROOT=/opt/rbenv RBENV_VERSION=2.2.0 /usr/bin/env HOME=/home/$AS_USER RAILS_ENV=staging nice -n 15 bundle exec bin/delayed_job $op -n 1 )"

This will also correct any other potential issues where environmental variables are set with SSHKit.