### PR TITLE
Set default path for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ You can also provide path, where to generate templates:
 
     $ bundle exec rails g capistrano:delayed_job:config config/templates
 
+If you're using a custom path, set "templates_path" variable in your `deploy.rb`:
+
+    set :templates_path, "config/templates"
+
+
 ### More Capistrano automation?
 
 If you'd like to streamline your Capistrano deploys, you might want to check

--- a/lib/capistrano/delayed_job/helpers.rb
+++ b/lib/capistrano/delayed_job/helpers.rb
@@ -17,7 +17,8 @@ module Capistrano
       end
 
       def dj_template(template_name)
-        config_file = "#{fetch(:templates_path)}/#{template_name}"
+        templates_path = fetch(:templates_path) || "config/deploy/templates"
+        config_file = "#{templates_path}/#{template_name}"
         # if no customized file, proceed with default
         unless File.exists?(config_file)
           config_file = File.join(File.dirname(__FILE__), "../../generators/capistrano/delayed_job/templates/#{template_name}")

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -33,7 +33,7 @@ namespace :delayed_job do
 
   before :setup, :defaults
 
-  %w[start stop restart].each do |command|
+  %w[start stop].each do |command|
     desc "#{command} delayed_job"
     task command do
       on roles fetch(:delayed_job_server_roles) do
@@ -44,6 +44,20 @@ namespace :delayed_job do
           # monit is disabled, use the standard init script
           sudo :service, fetch(:delayed_job_service), command
         end
+      end
+    end
+  end
+
+  desc "restart delayed_job"
+  task "restart" do
+    on roles fetch(:delayed_job_server_roles) do
+      if fetch(:delayed_job_monit_enabled)
+        # monit is enabled, use it to restart the service
+        sudo :monit, '-g', 'delayed_job', "restart"
+      else
+        # monit is disabled, use the standard init script
+        sudo :service, fetch(:delayed_job_service), "stop"
+        sudo :service, fetch(:delayed_job_service), "start"
       end
     end
   end

--- a/lib/generators/capistrano/delayed_job/USAGE.md
+++ b/lib/generators/capistrano/delayed_job/USAGE.md
@@ -6,4 +6,6 @@ The default path is "config/deploy/templates". You can override it like so:
 
     bundle rails generate capistrano:delayed_job:config "config/templates"
 
-If you override templates path, don't forget to set "templates_path" variable in your deploy.rb
+If you're using a custom path, set "templates_path" variable in your `deploy.rb`:
+
+    set :templates_path, "config/deploy/templates"


### PR DESCRIPTION
Creating a template caused it not to be used automatically when it was in the default location.
